### PR TITLE
fix: filter ion-page-hidden elements before asserting hydration in JQ…

### DIFF
--- a/cypress/e2e/get-from-supported-selector.spec.ts
+++ b/cypress/e2e/get-from-supported-selector.spec.ts
@@ -96,6 +96,50 @@ describe('Get From Supported Selector', () => {
     });
   });
 
+  describe('filters hidden-page elements BEFORE asserting hydration', () => {
+    beforeEach(() => {
+      cy.document().then((doc) => {
+        doc.body.insertAdjacentHTML(
+          'beforeend',
+          `<div class="ion-page ion-page-hidden">
+             <div class="testing-order-bug">Not Hydrated Hidden</div>
+           </div>
+           <div class="ion-page">
+             <div class="testing-order-bug hydrated">Visible Hydrated</div>
+           </div>`,
+        );
+      });
+    });
+
+    it('Chainable - does not fail when a hidden element lacks .hydrated', () => {
+      getFromSupportedSelector(cy.get('.testing-order-bug'))
+        .should('have.length', 1)
+        .should('have.text', 'Visible Hydrated');
+    });
+
+    it('JQuery - does not fail when a hidden element lacks .hydrated', () => {
+      cy.get('.testing-order-bug').then(($els) => {
+        getFromSupportedSelector($els)
+          .should('have.length', 1)
+          .should('have.text', 'Visible Hydrated');
+      });
+    });
+
+    it('Chainable - returns empty set without timing out when all matches are hidden', () => {
+      getFromSupportedSelector(
+        cy.get('.testing-order-bug').filter(':not(.hydrated)'),
+      ).should('have.length', 0);
+    });
+
+    it('JQuery - returns empty set without timing out when all matches are hidden', () => {
+      cy.get('.testing-order-bug')
+        .filter(':not(.hydrated)')
+        .then(($els) => {
+          getFromSupportedSelector($els).should('have.length', 0);
+        });
+    });
+  });
+
   describe('waiting for components hydration', () => {
     it('css selector', () => {
       getFromSupportedSelector<IonRange>('.ion-range-to-test-hydration')

--- a/cypress/e2e/get-from-supported-selector.spec.ts
+++ b/cypress/e2e/get-from-supported-selector.spec.ts
@@ -138,6 +138,22 @@ describe('Get From Supported Selector', () => {
           getFromSupportedSelector($els).should('have.length', 0);
         });
     });
+
+    it('css selector - returns empty set without timing out when all matches are hidden and not hydrated', () => {
+      cy.document().then((doc) => {
+        doc.body.insertAdjacentHTML(
+          'beforeend',
+          `<div class="ion-page ion-page-hidden">
+             <div class="testing-order-hidden-only">Hidden Only</div>
+           </div>`,
+        );
+      });
+
+      getFromSupportedSelector('.testing-order-hidden-only').should(
+        'have.length',
+        0,
+      );
+    });
   });
 
   describe('waiting for components hydration', () => {

--- a/src/helpers/get-from-supported-selector.ts
+++ b/src/helpers/get-from-supported-selector.ts
@@ -10,19 +10,10 @@ export function getFromSupportedSelector<T extends Element>(
   }
 
   if (isJQuery<T>(selector)) {
-    return filterOutHiddenPage(
-      cy
-        .wrap(selector)
-        .should('have.class', 'hydrated') as CypressIonicReturn<T>,
-    );
+    return filterThenAssertHydrated(cy.wrap(selector) as CypressIonicReturn<T>);
   }
 
-  return filterOutHiddenPage(
-    (selector as unknown as CypressIonicReturn<T>).should(
-      'have.class',
-      'hydrated',
-    ),
-  );
+  return filterThenAssertHydrated(selector as unknown as CypressIonicReturn<T>);
 }
 
 function filterOutHiddenPage<T extends Element>(
@@ -31,6 +22,20 @@ function filterOutHiddenPage<T extends Element>(
   return subject.not(
     '.ion-page-hidden, .ion-page-hidden *',
   ) as unknown as CypressIonicReturn<T>;
+}
+
+function filterThenAssertHydrated<T extends Element>(
+  subject: CypressIonicReturn<T>,
+): CypressIonicReturn<T> {
+  return subject.then((elements) => {
+    const $visible = elements.not(
+      '.ion-page-hidden, .ion-page-hidden *',
+    ) as unknown as JQuery<T>;
+    if ($visible.length === 0) {
+      return cy.wrap($visible);
+    }
+    return cy.wrap($visible).should('have.class', 'hydrated');
+  }) as unknown as CypressIonicReturn<T>;
 }
 
 function isJQuery<T extends Element>(

--- a/src/helpers/get-from-supported-selector.ts
+++ b/src/helpers/get-from-supported-selector.ts
@@ -1,4 +1,7 @@
 import { CypressIonicReturn, SupportedSelectors } from '../interfaces';
+
+const HIDDEN_PAGE_SELECTOR = '.ion-page-hidden, .ion-page-hidden *';
+
 /**
  * @internal
  */
@@ -6,7 +9,7 @@ export function getFromSupportedSelector<T extends Element>(
   selector: SupportedSelectors<T>,
 ): CypressIonicReturn<T> {
   if (typeof selector === 'string') {
-    return filterOutHiddenPage(cy.get<T>(`${selector}.hydrated`));
+    return filterThenAssertHydrated(cy.get<T>(selector));
   }
 
   if (isJQuery<T>(selector)) {
@@ -16,21 +19,11 @@ export function getFromSupportedSelector<T extends Element>(
   return filterThenAssertHydrated(selector as unknown as CypressIonicReturn<T>);
 }
 
-function filterOutHiddenPage<T extends Element>(
-  subject: CypressIonicReturn<T>,
-): CypressIonicReturn<T> {
-  return subject.not(
-    '.ion-page-hidden, .ion-page-hidden *',
-  ) as unknown as CypressIonicReturn<T>;
-}
-
 function filterThenAssertHydrated<T extends Element>(
   subject: CypressIonicReturn<T>,
 ): CypressIonicReturn<T> {
   return subject.then((elements) => {
-    const $visible = elements.not(
-      '.ion-page-hidden, .ion-page-hidden *',
-    ) as unknown as JQuery<T>;
+    const $visible = elements.not(HIDDEN_PAGE_SELECTOR) as unknown as JQuery<T>;
     if ($visible.length === 0) {
       return cy.wrap($visible);
     }


### PR DESCRIPTION
…uery/Chainable branches

In the JQuery and Chainable branches, the hydration assertion ran on the full element set before hidden-page elements were filtered out. If all elements were on hidden pages and lacked the .hydrated class, Cypress's .not() command would retry until timeout rather than returning an empty set.

The fix uses jQuery's native .not() synchronously inside a .then() callback to filter hidden elements first, then skips the hydration assertion when the filtered set is empty.